### PR TITLE
feat: チャット履歴を全てのbotで統合

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import { fs } from 'mz';
 import { commandSelector, interactionSelector } from './bot/commands.js';
 import * as DotBotFunctions from './bot/dot_function';
 import { joinVoiceChannel, leftVoiceChannel } from './bot/dot_function/room.js';
+import { LiteLLMMode } from './bot/service/chatService.js';
 import * as SpeakService from './bot/service/speakService.js';
 import { initializeCoeiroSpeakerIds } from './common/common.js';
 import { Logger } from './common/logger.js';
@@ -22,7 +23,7 @@ import { initJob } from './job/job.js';
 import { SpeakerRepository } from './model/repository/speakerRepository.js';
 import { TypeOrm } from './model/typeorm/typeorm.js';
 import { routers } from './routers.js';
-import { GPTMode, LogLevel } from './type/types.js';
+import { LogLevel } from './type/types.js';
 
 // read config file
 const json = process.argv[2];
@@ -96,6 +97,10 @@ const dmCommands = [
     .setName('delete')
     .setDescription('ChatGPTとのチャット履歴を削除します')
     .addBooleanOption((option) => option.setName('last').setDescription('直前のみ削除します').setRequired(false)),
+  new SlashCommandBuilder()
+    .setName('revert')
+    .setDescription('最新のチャット履歴を復元します')
+    .addStringOption((option) => option.setName('uuid').setDescription('会話ID').setRequired(false)),
   new SlashCommandBuilder()
     .setName(CONFIG.COMMAND.SPEAKER_CONFIG.COMMAND_NAME_SHORT)
     .setDescription('スピーカーの設定を行う')
@@ -206,12 +211,12 @@ DISCORD_CLIENT.on('messageCreate', async (message: Message) => {
     message.content.includes(`<@${DISCORD_CLIENT.user?.id}>`) &&
     message.content.trimEnd() !== `<@${DISCORD_CLIENT.user?.id}>`
   ) {
-    await DotBotFunctions.Chat.talk(message, message.content, CONFIG.OPENAI.DEFAULT_MODEL, GPTMode.DEFAULT);
+    await DotBotFunctions.Chat.talk(message, message.content, CONFIG.OPENAI.DEFAULT_MODEL, LiteLLMMode.DEFAULT);
     return;
   }
 
   if (message.channel.type === ChannelType.DM) {
-    await DotBotFunctions.Chat.talk(message, message.content, CONFIG.OPENAI.DEFAULT_MODEL, GPTMode.DEFAULT);
+    await DotBotFunctions.Chat.talk(message, message.content, CONFIG.OPENAI.DEFAULT_MODEL, LiteLLMMode.DEFAULT);
     return;
   }
 

--- a/src/bot/commands.ts
+++ b/src/bot/commands.ts
@@ -2,9 +2,9 @@ import { CacheType, ChatInputCommandInteraction, EmbedBuilder, Message } from 'd
 import { findVoiceFromId, initializeCoeiroSpeakerIds } from '../common/common';
 import { CONFIG } from '../config/config';
 import { UsersRepository } from '../model/repository/usersRepository';
-import { GPTMode } from '../type/types';
 import * as DotBotFunctions from './dot_function';
 import * as BotFunctions from './function';
+import { LiteLLMMode } from './service/chatService';
 
 /**
  * 渡されたコマンドから処理を実行する
@@ -20,7 +20,7 @@ export async function commandSelector(message: Message) {
   content.shift();
   switch (command) {
     case CONFIG.NAME: {
-      await DotBotFunctions.Chat.talk(message, content.join(' '), CONFIG.OPENAI.DEFAULT_MODEL, GPTMode.DEFAULT);
+      await DotBotFunctions.Chat.talk(message, content.join(' '), CONFIG.OPENAI.DEFAULT_MODEL, LiteLLMMode.DEFAULT);
       break;
     }
     // case CONFIG.COMMAND.SPEAK.COMMAND_NAME: {
@@ -208,6 +208,10 @@ export async function interactionSelector(interaction: ChatInputCommandInteracti
         return;
       }
       await BotFunctions.Chat.setModel(interaction, model);
+      break;
+    }
+    case 'revert': {
+      await BotFunctions.Chat.revert(interaction);
       break;
     }
   }

--- a/src/bot/function/chat.ts
+++ b/src/bot/function/chat.ts
@@ -2,9 +2,11 @@ import axios from 'axios';
 import { CacheType, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
 import { Logger } from '../../common/logger';
 import { CONFIG, LiteLLMModel } from '../../config/config';
-import { GPTMode, LogLevel, ModelResponse } from '../../type/types';
+import { ChatHistory } from '../../model/models';
+import { ChatHistoryRepository } from '../../model/repository/chatHistoryRepository';
+import { LogLevel, ModelResponse } from '../../type/types';
 import * as ChatService from '../service/chatService';
-import { gptList } from '../service/chatService';
+import { llmList } from '../service/chatService';
 
 /**
  * ChatGPTの会話データの削除
@@ -15,7 +17,7 @@ export async function deleteChatData(interaction: ChatInputCommandInteraction<Ca
     await interaction.reply('データが存在しないみたい？');
     return;
   }
-  const gpt = gptList.gpt.find((c) => c.id === id);
+  const gpt = llmList.llm.find((c) => c.id === id);
   if (!gpt) {
     await interaction.reply('会話データが存在しないみたい？');
     return;
@@ -32,7 +34,7 @@ export async function deleteChatData(interaction: ChatInputCommandInteraction<Ca
     await interaction.reply({ embeds: [send] });
     return;
   }
-  gptList.gpt = gptList.gpt.filter((c) => c.id !== id);
+  llmList.llm = llmList.llm.filter((c) => c.id !== id);
   Logger.put({
     guild_id: interaction.guild?.id,
     channel_id: interaction.channel?.id,
@@ -47,7 +49,7 @@ export async function deleteChatData(interaction: ChatInputCommandInteraction<Ca
 function getIdInfo(interaction: ChatInputCommandInteraction<CacheType>) {
   const guild = interaction.guild;
   if (!guild) {
-    return { id: interaction.channel?.id ?? interaction.user.dmChannel?.id, isGuild: false };
+    return { id: interaction.user.id, isGuild: false };
   }
   return { id: guild.id, isGuild: true };
 }
@@ -70,12 +72,98 @@ export async function showModelList(interaction: ChatInputCommandInteraction<Cac
 export async function setModel(interaction: ChatInputCommandInteraction<CacheType>, model: string) {
   const { id, isGuild } = getIdInfo(interaction);
 
-  let gpt = gptList.gpt.find((c) => c.id === interaction.user.id);
+  let gpt = llmList.llm.find((c) => c.id === interaction.user.id);
   if (!gpt) {
-    gpt = await ChatService.initalize(interaction.user.id, model as LiteLLMModel, GPTMode.DEFAULT, isGuild);
-    ChatService.gptList.gpt.push(gpt);
+    gpt = await ChatService.initalize(interaction.user.id, model as LiteLLMModel, ChatService.LiteLLMMode.DEFAULT, isGuild);
+    ChatService.llmList.llm.push(gpt);
   }
 
   gpt.model = model as LiteLLMModel;
   await interaction.reply(`モデルを${model}に設定したよ～！`);
+}
+
+export async function revert(interaction: ChatInputCommandInteraction<CacheType>) {
+  await interaction.deferReply();
+
+  try {
+    const uuid = interaction.options.getString('uuid');
+    const { id, isGuild } = getIdInfo(interaction);
+
+    if (!id) {
+      const errorEmbed = new EmbedBuilder()
+        .setColor('#ff0000')
+        .setTitle('エラー')
+        .setDescription('チャンネルIDが見つかりませんでした。');
+      await interaction.editReply({ embeds: [errorEmbed] });
+      return;
+    }
+
+    let chatHistory: ChatHistory | null = null;
+    const chatHistoryRepository = new ChatHistoryRepository();
+
+    if (uuid) {
+      chatHistory = await chatHistoryRepository.get(uuid);
+    } else {
+      // データベースから最新のチャット履歴を取得
+      chatHistory = await chatHistoryRepository.getLatestByChannelId(id);
+    }
+
+    if (!chatHistory) {
+      const errorEmbed = new EmbedBuilder()
+        .setColor('#ff0000')
+        .setTitle('エラー')
+        .setDescription('チャット履歴が見つかりませんでした。');
+      await interaction.editReply({ embeds: [errorEmbed] });
+      return;
+    }
+
+    // llmListから該当するチャットセッションを探す
+    let llm: ChatService.LiteLLM | undefined;
+    if (uuid) {
+      llm = ChatService.llmList.llm.find((llm) => llm.uuid === uuid);
+    } else {
+      llm = ChatService.llmList.llm.find((llm) => llm.id === id);
+    }
+
+    if (llm) {
+      // 現在のチャット履歴がある場合は上書きしない
+      const warningEmbed = new EmbedBuilder()
+        .setColor('#ffaa00')
+        .setTitle('履歴が存在する')
+        .setDescription('まだチャットが残ってるみたい～！そのまま喋れるよ！');
+
+      await interaction.editReply({ embeds: [warningEmbed] });
+      return;
+    } else {
+      // 現在のチャット履歴がない場合は、DBから取得した履歴で上書きする
+      const llm = await ChatService.initalize(id, chatHistory.model, chatHistory.mode, isGuild);
+      ChatService.llmList.llm.push({ ...llm, chat: chatHistory.content, uuid: chatHistory.uuid });
+    }
+
+    const successEmbed = new EmbedBuilder()
+      .setColor('#00ff00')
+      .setTitle('復元完了')
+      .setDescription(
+        `チャット履歴を復元しました。\n履歴UUID: ${chatHistory.uuid}\nメッセージ数: ${chatHistory.content.length - 1}`
+      );
+
+    await interaction.editReply({ embeds: [successEmbed] });
+  } catch (error) {
+    const err = error as Error;
+    Logger.put({
+      guild_id: interaction.guild?.id,
+      channel_id: interaction.channel?.id,
+      user_id: interaction.user.id,
+      level: LogLevel.ERROR,
+      event: 'ChatGPT',
+      message: [`Revert: ${err.message}`],
+    });
+
+    const errorEmbed = new EmbedBuilder()
+      .setColor('#ff0000')
+      .setTitle('エラー')
+      .setDescription('チャット履歴の復元中にエラーが発生しました。');
+
+    await interaction.editReply({ embeds: [errorEmbed] });
+  }
 }

--- a/src/bot/service/chatService.ts
+++ b/src/bot/service/chatService.ts
@@ -4,9 +4,9 @@ import { ChatCompletionMessageParam } from 'openai/resources';
 import { CONFIG, LiteLLMModel } from '../../config/config.js';
 import { CHATBOT_LEMON_TEMPLATE, CHATBOT_LIME_TEMPLATE } from '../../constant/constants.js';
 
-export const gptList = { gpt: [] as ChatGPT[] };
+export const llmList = { llm: [] as LiteLLM[] };
 
-export async function initalize(id: string, model: LiteLLMModel, mode: GPTMode, isGuild: boolean) {
+export async function initalize(id: string, model: LiteLLMModel, mode: LiteLLMMode, isGuild: boolean) {
   const openai = new OpenAI({
     organization: CONFIG.OPENAI.ORG,
     project: CONFIG.OPENAI.PROJECT,
@@ -14,15 +14,17 @@ export async function initalize(id: string, model: LiteLLMModel, mode: GPTMode, 
     maxRetries: 3,
     baseURL: 'http://localhost:4001',
   });
-  const gpt: ChatGPT = {
+  const gpt: LiteLLM = {
     id,
+    uuid: crypto.randomUUID(),
     openai: openai,
     model: model,
     chat: [],
     isGuild: isGuild,
+    memory: false,
     timestamp: dayjs(),
   };
-  if (mode === GPTMode.DEFAULT) {
+  if (mode === LiteLLMMode.DEFAULT) {
     gpt.chat.push({
       role: Role.SYSTEM,
       content: CONFIG.NAME === 'lemon' ? CHATBOT_LEMON_TEMPLATE : CHATBOT_LIME_TEMPLATE,
@@ -31,16 +33,18 @@ export async function initalize(id: string, model: LiteLLMModel, mode: GPTMode, 
   return gpt;
 }
 
-export type ChatGPT = {
+export type LiteLLM = {
   id: string;
+  uuid: string;
   openai: OpenAI;
   model: LiteLLMModel;
   chat: ChatCompletionMessageParam[];
   isGuild: boolean;
+  memory: boolean;
   timestamp: dayjs.Dayjs;
 };
 
-export enum GPTMode {
+export enum LiteLLMMode {
   DEFAULT = 'default',
   NOPROMPT = 'no_prompt',
 }

--- a/src/job/job.ts
+++ b/src/job/job.ts
@@ -1,18 +1,17 @@
-import * as cron from 'node-cron';
-import { UsersRepository } from '../model/repository/usersRepository.js';
 import dayjs from 'dayjs';
+import * as cron from 'node-cron';
+import { llmList } from '../bot/service/chatService.js';
 import { Logger } from '../common/logger.js';
 import { LogLevel } from '../type/types.js';
-import { gptList } from '../bot/service/chatService.js';
 
 export async function initJob() {
   /**
    * 1分毎に実行されるタスク
    */
   cron.schedule('* * * * *', async () => {
-    gptList.gpt.map(async (c) => {
+    llmList.llm.map(async (c) => {
       if (c.timestamp.isBefore(dayjs().subtract(30, 'minute'))) {
-        gptList.gpt = gptList.gpt.filter((g) => g.id !== c.id);
+        llmList.llm = llmList.llm.filter((g) => g.id !== c.id);
         await Logger.put({
           guild_id: c.isGuild ? c.id : undefined,
           channel_id: c.isGuild ? undefined : c.id,

--- a/src/model/models/botInfo.ts
+++ b/src/model/models/botInfo.ts
@@ -1,0 +1,23 @@
+import { BaseEntity, Column, CreateDateColumn, DeleteDateColumn, Entity, OneToMany, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+import { ChatHistory } from './chatHistory.js';
+
+@Entity({ engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
+export class BotInfo extends BaseEntity {
+  @PrimaryColumn({ type: 'bigint', width: 20 })
+  bot_id!: number;
+
+  @Column({ type: 'varchar', width: 255 })
+  name!: string | null;
+
+  @CreateDateColumn({ type: 'datetime', nullable: false })
+  created_at!: Date;
+
+  @UpdateDateColumn({ type: 'datetime', nullable: false })
+  updated_at!: Date;
+
+  @DeleteDateColumn({ type: 'datetime', nullable: true })
+  deleted_at: Date | null = null;
+
+  @OneToMany(() => ChatHistory, (chatHistory) => chatHistory.bot_id)
+  chat_histories!: ChatHistory[];
+}

--- a/src/model/models/chatHistory.ts
+++ b/src/model/models/chatHistory.ts
@@ -1,0 +1,61 @@
+import { ChatCompletionMessageParam } from 'openai/resources';
+import {
+  BaseEntity,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  Relation,
+  UpdateDateColumn,
+} from 'typeorm';
+import { LiteLLMMode } from '../../bot/service/chatService.js';
+import { LiteLLMModel } from '../../config/config.js';
+import { BotInfo } from './botInfo.js';
+
+@Entity({ engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
+export class ChatHistory extends BaseEntity {
+  @PrimaryColumn({ type: 'varchar', width: 255 })
+  uuid!: string;
+
+  @Column({ type: 'bigint', width: 20 })
+  bot_id!: string;
+
+  @Column({ type: 'bigint', width: 20 })
+  channel_id!: string;
+
+  @Column({ type: 'varchar', width: 20 })
+  channel_type!: ChatHistoryChannelType;
+
+  @Column({ type: 'varchar', width: 255, nullable: true })
+  name!: string | null;
+
+  @Column({ type: 'json' })
+  content!: ChatCompletionMessageParam[];
+
+  @Column({ type: 'varchar', width: 255 })
+  model!: LiteLLMModel;
+
+  @Column({ type: 'varchar', width: 255 })
+  mode!: LiteLLMMode;
+
+  @CreateDateColumn({ type: 'datetime', nullable: false })
+  created_at!: Date;
+
+  @UpdateDateColumn({ type: 'datetime', nullable: false })
+  updated_at!: Date;
+
+  @DeleteDateColumn({ type: 'datetime', nullable: true })
+  deleted_at: Date | null = null;
+
+  @ManyToOne(() => BotInfo, (botInfo) => botInfo.bot_id)
+  @JoinColumn({ name: 'bot_id', referencedColumnName: 'bot_id' })
+  bot_info!: Relation<BotInfo>;
+}
+
+export enum ChatHistoryChannelType {
+  DM = 'dm',
+  GUILD = 'guild',
+}

--- a/src/model/models/index.ts
+++ b/src/model/models/index.ts
@@ -1,3 +1,5 @@
+export { BotInfo } from './botInfo.js';
+export { ChatHistory } from './chatHistory.js';
 export { Color } from './color.js';
 export { Gacha } from './gacha.js';
 export { Guild } from './guild.js';

--- a/src/model/repository/chatHistoryRepository.ts
+++ b/src/model/repository/chatHistoryRepository.ts
@@ -1,0 +1,133 @@
+import { DeepPartial, Repository } from 'typeorm';
+import { DISCORD_CLIENT } from '../../constant/constants.js';
+import * as Models from '../models/index.js';
+import { TypeOrm } from '../typeorm/typeorm.js';
+
+export class ChatHistoryRepository {
+  private repository: Repository<Models.ChatHistory>;
+
+  constructor() {
+    this.repository = TypeOrm.dataSource.getRepository(Models.ChatHistory);
+  }
+
+  /**
+   * UUIDからチャット履歴を取得する
+   * @param uuid チャット履歴のUUID
+   * @returns Promise<ChatHistory | null>
+   */
+  public async get(uuid: string): Promise<Models.ChatHistory | null> {
+    const chatHistory = await this.repository.findOne({ where: { uuid } });
+    return chatHistory;
+  }
+
+  /**
+   * チャンネルIDからチャット履歴を取得する
+   * @param channelId チャンネルID
+   * @returns Promise<ChatHistory[]>
+   */
+  public async getLatestByChannelId(channelId: string): Promise<Models.ChatHistory | null> {
+    const botId = DISCORD_CLIENT.user?.id;
+    if (!botId) {
+      return null;
+    }
+
+    const chatHistory = await this.repository.findOne({
+      where: { bot_id: botId, channel_id: channelId },
+      order: { created_at: 'DESC' },
+    });
+    return chatHistory;
+  }
+
+  /**
+   * ユーザーIDに関連するチャット履歴を取得する
+   * @param userId ユーザーID
+   * @param limit 取得件数（デフォルト: 50）
+   * @param offset オフセット（デフォルト: 0）
+   * @returns Promise<ChatHistory[]>
+   */
+  public async getByUserId(userId: string, limit: number = 50, offset: number = 0): Promise<Models.ChatHistory[]> {
+    // DMチャンネルの履歴を取得
+    // 注意: 実際のDiscord DMチャンネルIDの形式に応じて、より具体的なフィルタリングロジックが必要になる場合があります
+    const chatHistories = await this.repository
+      .createQueryBuilder('chat_history')
+      .where('chat_history.channel_type = :channelType', { channelType: 'DM' })
+      .andWhere('JSON_EXTRACT(chat_history.content, "$[*].role") LIKE :userId', { userId: `%${userId}%` })
+      .orderBy('chat_history.updated_at', 'DESC')
+      .take(limit)
+      .skip(offset)
+      .getMany();
+
+    return chatHistories;
+  }
+
+  /**
+   * すべてのチャット履歴を取得する（ページネーション対応）
+   * @param limit 取得件数（デフォルト: 50）
+   * @param offset オフセット（デフォルト: 0）
+   * @param channelId チャンネルID（オプション）
+   * @returns Promise<ChatHistory[]>
+   */
+  public async getAll(limit: number = 50, offset: number = 0, channelId?: string): Promise<Models.ChatHistory[]> {
+    const whereCondition: any = {};
+
+    if (channelId && channelId.trim() !== '' && channelId !== 'all') {
+      whereCondition.channel_id = channelId;
+    }
+
+    const chatHistories = await this.repository.find({
+      where: whereCondition,
+      order: { created_at: 'DESC' },
+      take: limit,
+      skip: offset,
+    });
+    return chatHistories;
+  }
+
+  /**
+   * チャット履歴を保存・更新する（upsert）
+   * @param chatHistory チャット履歴データ
+   * @returns Promise<void>
+   */
+  public async save(chatHistory: DeepPartial<Models.ChatHistory>): Promise<void> {
+    await this.repository.save(chatHistory);
+  }
+
+  /**
+   * UUIDをキーにしてcontentを上書き保存する
+   * @param uuid チャット履歴のUUID
+   * @param content 新しいコンテンツ
+   * @returns Promise<void>
+   */
+  public async upsertByUuid(uuid: string, content: Models.ChatHistory['content']): Promise<void> {
+    const existingChatHistory = await this.get(uuid);
+
+    if (existingChatHistory) {
+      // 既存のレコードがある場合は content を更新
+      await this.repository.save({
+        uuid,
+        content,
+      });
+    } else {
+      // 既存のレコードがない場合はエラーを投げる（UUIDが存在しない）
+      throw new Error(`ChatHistory with UUID ${uuid} not found`);
+    }
+  }
+
+  /**
+   * チャット履歴を削除する（ソフトデリート）
+   * @param uuid チャット履歴のUUID
+   * @returns Promise<void>
+   */
+  public async delete(uuid: string): Promise<void> {
+    await this.repository.softDelete({ uuid });
+  }
+
+  /**
+   * チャット履歴を完全に削除する
+   * @param uuid チャット履歴のUUID
+   * @returns Promise<void>
+   */
+  public async hardDelete(uuid: string): Promise<void> {
+    await this.repository.delete({ uuid });
+  }
+}

--- a/src/model/typeorm/typeorm.ts
+++ b/src/model/typeorm/typeorm.ts
@@ -26,6 +26,8 @@ export class TypeOrm {
       Models.Speaker,
       Models.Log,
       Models.UserSetting,
+      Models.BotInfo,
+      Models.ChatHistory,
     ], // 利用するエンティティ。パスでの指定も可能
   });
 }

--- a/src/type/types.ts
+++ b/src/type/types.ts
@@ -18,7 +18,7 @@ export enum LogLevel {
   SYSTEM = 'system',
 }
 
-export type ChatGPT = {
+export type LiteLLM = {
   id: string;
   openai: OpenAI;
   model: LiteLLMModel;
@@ -26,11 +26,6 @@ export type ChatGPT = {
   isGuild: boolean;
   timestamp: dayjs.Dayjs;
 };
-
-export enum GPTMode {
-  DEFAULT = 'default',
-  NOPROMPT = 'no_prompt',
-}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type VisionMessage = {


### PR DESCRIPTION
- DMの場合channel_idに詰めるのはuser_idとした
- pause, resumeの追加(チャットを一時停止する)
- botの名前と色情報を追加するテーブルを追加